### PR TITLE
[Bugfix] Resetting Project details on Projects update

### DIFF
--- a/src/components/ProjectList/ProjectList.js
+++ b/src/components/ProjectList/ProjectList.js
@@ -73,18 +73,27 @@ export default class ProjectList extends React.Component {
     Promise.all(promiseArray)
       .then(
         results => {
-          const sortedProjects = results
-            .map(function(project) {
-              return {
-                name: project.data.repository.full_name,
-                status: project.data.state,
-              };
-            })
-            .sort(this.sortProjects);
-
-          this.setState({
-            projects: sortedProjects,
+          const sortedProjects = results.map(project => {
+            return {
+              name: project.data.repository.full_name,
+              status: project.data.state,
+            };
           });
+
+          const updatedProjects = [...this.state.projects];
+          let shouldUpdateState = false;
+          sortedProjects.forEach((project, index) => {
+            if (updatedProjects[index].status !== project.status) {
+              updatedProjects[index].status = project.status;
+              shouldUpdateState = true;
+            }
+          });
+
+          if (shouldUpdateState) {
+            this.setState({
+              projects: updatedProjects,
+            });
+          }
         },
         reason => {
           console.log('error', reason);


### PR DESCRIPTION
This closes #52 

Please not that I have removed the `.sort` on row 83. This is unrelated to the bug fix.

Motivation: 
The state has all the projects in an array, in the order we want the projects to be displayed.
The `promiseArray` have the projects in the same order as they are in the state. It is therefore unnecessary to sort the array, since it is already sorted.