### PR TITLE
[#75] Added project icon for each project

### DIFF
--- a/src/components/Filter/Filter.css
+++ b/src/components/Filter/Filter.css
@@ -42,3 +42,11 @@
     margin: auto;
     margin-bottom: 20px;
 }
+.project-icon-img {
+    margin: 0 4px 0px 4px;
+    border-radius: 50%;
+    vertical-align: middle;
+    max-width: 64px;
+    min-width: 16px;
+    width: 8vw;
+}

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -4,7 +4,7 @@ import { Delete } from 'react-feather';
 import './Filter.css';
 
 import ProjectDetails from '../ProjectDetails/ProjectDetails';
-
+const projectIconMaxSize = 64;
 export default class Filter extends PureComponent {
   printProjectList = proj => {
     return proj.map((project, index) => {
@@ -20,6 +20,7 @@ export default class Filter extends PureComponent {
               rel="noopener noreferrer"
               href={`https://github.com/${project.name}`}
             >
+              <img  className="project-icon-img" src={"https://github.com/" + project.name.substring(0,project.name.indexOf('/')) + ".png?size=" + projectIconMaxSize}></img>
               {project.name}
             </a>{' '}
             <button


### PR DESCRIPTION
Fixes #75 
Instead of using the GH API, I found a simple way to add image at https://github.com/sindresorhus/refined-github/issues/95#issuecomment-204806394.
Desktop: 1600x900
![Screenshot_2020-10-19 CommitStatus(1)](https://user-images.githubusercontent.com/28699912/96412510-ea4e4080-1207-11eb-920d-a14b61832d36.png)

Galaxy S9: 360x740
![Screenshot_2020-10-19 CommitStatus(2)](https://user-images.githubusercontent.com/28699912/96412583-fdf9a700-1207-11eb-95f8-14d8f7b1e88d.png)

I have added a global in `Filter.js` as `projectIconMaxSize` which defines the maximum size of the image to fetch.

- [x] Test for async
- [x] Ready for review?
